### PR TITLE
Allow for entries searches comprising of no extenstion.   if no '.' is specified then '.*' patterns can be assumed.

### DIFF
--- a/AbroadConcepts.IO/AbroadConcepts.IO.csproj
+++ b/AbroadConcepts.IO/AbroadConcepts.IO.csproj
@@ -8,7 +8,7 @@
     <PropertyGroup>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
-        <Version>9.0.4</Version>
+        <Version>9.0.5</Version>
         <Authors>Craig H. Knapp</Authors>
         <Company>Abroad Concepts</Company>
         <RepositoryUrl>https://github.com/craighknapp12/AbroadConcepts.Libraries</RepositoryUrl>

--- a/AbroadConcepts.IO/ZipArchiver.cs
+++ b/AbroadConcepts.IO/ZipArchiver.cs
@@ -96,6 +96,11 @@ public class ZipArchiver : IDisposable
 
     public List<ZipArchiveEntry> GetEntries(string? pattern = default)
     {
+        if (pattern?.IndexOf('.') == -1)
+        {
+            pattern += ".*";
+        }
+
         var regPattern = !string.IsNullOrEmpty(pattern) ? "^" + pattern + "$" : "^*$";
         Regex reg = new Regex(regPattern);
 

--- a/TestAbroadConcept.IO/TestZipArchiver.cs
+++ b/TestAbroadConcept.IO/TestZipArchiver.cs
@@ -54,6 +54,16 @@ public class TestZipArchiver
         Assert.Single(items);
     }
     [Fact]
+    public void TestAddFilesWithGetEntriesNoFileExtension()
+    {
+        using var stream = new MemoryStream();
+        using var zip = new ZipArchiver(stream);
+        zip.Add("*host.dll");
+
+        var items = zip.GetEntries("*host");
+        Assert.Single(items);
+    }
+    [Fact]
     public void TestExtractFilesToZipArchiver()
     {
         using var stream = new MemoryStream();


### PR DESCRIPTION
Allow for entries searches comprising of no extenstion.   if no '.' is specified then '.*' patterns can be assumed.